### PR TITLE
Fix footer format

### DIFF
--- a/zetz-mode.el
+++ b/zetz-mode.el
@@ -304,4 +304,4 @@
 
 ;;
 (provide 'zetz-mode)
-;; zetz-mode.el ends here
+;;; zetz-mode.el ends here


### PR DESCRIPTION
It requires three semicolons not two